### PR TITLE
Dispatch rabbitmq_messages once per queue

### DIFF
--- a/rabbitmq.py
+++ b/rabbitmq.py
@@ -14,7 +14,7 @@ import re
 RABBIT_API_URL = "{scheme}://{host}:{port}/api"
 
 QUEUE_MESSAGE_STATS = ['messages', 'messages_ready', 'messages_unacknowledged']
-QUEUE_STATS = ['memory', 'messages', 'consumers']
+QUEUE_STATS = ['memory', 'consumers']
 
 MESSAGE_STATS = ['ack', 'publish', 'publish_in', 'publish_out', 'confirm',
                  'deliver', 'deliver_noack', 'get', 'get_noack', 'deliver_get',


### PR DESCRIPTION
`messages` appears in both `QUEUE_STATS` and `QUEUE_MESSAGE_STATS`, so every queue's depth gauge is dispatched twice per read interval — confirmed in production (2x datapoint rate vs sibling gauges like `rabbitmq_messages_ready`). Costs ~426 redundant datapoints/min in Sumo Logic.

Removing it from `QUEUE_STATS` (keeping it grouped with the other queue-depth stats in `QUEUE_MESSAGE_STATS`) halves the `rabbitmq_messages` datapoint rate; series identity is unchanged.

Consumed by goodeggs-collectd; submodule bump to follow.